### PR TITLE
Load api key from environment variable instead of _config.yml

### DIFF
--- a/lib/environment-settings.rb
+++ b/lib/environment-settings.rb
@@ -1,0 +1,7 @@
+module Jekyll
+  class EnvironmentVariablesGenerator < Generator
+    def generate(site)
+      site.config['google_maps_api_key'] = ENV['GOOGLE_MAPS_API_KEY']
+    end
+  end
+end

--- a/lib/environment-settings.rb
+++ b/lib/environment-settings.rb
@@ -1,7 +1,7 @@
 module Jekyll
   class EnvironmentVariablesGenerator < Generator
     def generate(site)
-      site.config['google_maps_api_key'] = ENV['GOOGLE_MAPS_API_KEY']
+      site.config["google_maps_api_key"] = ENV["GOOGLE_MAPS_API_KEY"]
     end
   end
 end

--- a/lib/jekyll-maps.rb
+++ b/lib/jekyll-maps.rb
@@ -5,6 +5,7 @@ require "jekyll-maps/google_map_tag"
 require "jekyll-maps/location_finder"
 require "jekyll-maps/options_parser"
 require "jekyll-maps/version"
+require "environment-settings"
 
 module Jekyll
   module Maps

--- a/lib/jekyll-maps/google_map_api.rb
+++ b/lib/jekyll-maps/google_map_api.rb
@@ -28,7 +28,7 @@ HTML
         private
         def load_google_maps_api
           api_key = @config.fetch("site", {})
-	            .fetch("GOOGLE_MAPS_API_KEY", "")
+            .fetch("GOOGLE_MAPS_API_KEY", "")
           <<HTML
 <script async defer src='https://maps.googleapis.com/maps/api/js?key=#{api_key}&callback=#{Jekyll::Maps::GoogleMapTag::JS_LIB_NAME}.initializeMap'></script>
 HTML

--- a/lib/jekyll-maps/google_map_api.rb
+++ b/lib/jekyll-maps/google_map_api.rb
@@ -27,9 +27,8 @@ HTML
 
         private
         def load_google_maps_api
-          api_key = @config.fetch("maps", {})
-            .fetch("google", {})
-            .fetch("api_key", "")
+          api_key = @config.fetch("site", {})
+	            .fetch("GOOGLE_MAPS_API_KEY", "")
           <<HTML
 <script async defer src='https://maps.googleapis.com/maps/api/js?key=#{api_key}&callback=#{Jekyll::Maps::GoogleMapTag::JS_LIB_NAME}.initializeMap'></script>
 HTML


### PR DESCRIPTION
So if your site config is open on github you can still securely add your api key using environment variables.

Let me know if you need me to want to make it environment variable OR _config instead.

Resolves #19 