### PR TITLE
Fix filter checking logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage
 _site
 node_modules
 .DS_store
+.#*

--- a/lib/jekyll-maps/location_finder.rb
+++ b/lib/jekyll-maps/location_finder.rb
@@ -76,12 +76,14 @@ module Jekyll
       def match_filters?(doc)
         @options[:filters].each do |filter, value|
           if filter == "src"
-            return true unless doc.respond_to?(:relative_path)
-            return false unless doc.relative_path.start_with?(value)
+            if doc.respond_to?(:relative_path)
+              return false unless doc.relative_path.start_with?(value)
+            end
           elsif doc[filter].nil? || doc[filter] != value
             return false
           end
         end
+        return true
       end
 
       private

--- a/spec/fixtures/_data/usa/cities.yml
+++ b/spec/fixtures/_data/usa/cities.yml
@@ -1,0 +1,23 @@
+- title: Boston
+  state: MA
+  location:
+    latitude: 42.358935
+    longitude: -71.056772
+
+- title: New York
+  state: NY
+  location:
+    latitude: 40.710399 
+    longitude: -74.001612
+
+- title: Philadelphia
+  state: PA
+  location:
+    latitude: 39.949775 
+    longitude: -75.164116
+
+- title: Pittsburgh
+  state: PA
+  location:
+    latitude: 40.440482 
+    longitude: -79.996974

--- a/spec/fixtures/_data/usa/observatories.yml
+++ b/spec/fixtures/_data/usa/observatories.yml
@@ -1,0 +1,17 @@
+- title: Apache Point Observatory
+  state: NM
+  location:
+    latitude: 32.780341
+    longitude: -105.819661
+
+- title: Naylor Observatory
+  state: PA
+  location:
+    latitude: 40.149433
+    longitude: -76.895617
+
+- title: Adams Observatory
+  state: IA
+  location:
+    latitude: 42.092937
+    longitude: -93.569096

--- a/spec/location_finder_spec.rb
+++ b/spec/location_finder_spec.rb
@@ -117,7 +117,7 @@ describe Jekyll::Maps::LocationFinder do
     end
   end
 
-  context "filtering locations" do
+  context "filtering posts by location" do
     let(:options) { Jekyll::Maps::OptionsParser.parse("src='_posts' country='de'") }
     let(:finder)  { Jekyll::Maps::LocationFinder.new(options) }
     let(:actual)  { finder.find(site, page) }
@@ -128,6 +128,14 @@ describe Jekyll::Maps::LocationFinder do
         expect(location).to include(:title => "Berlin")
       end
     end
+  end
+
+  context "filtering data by location (state filter first)" do
+    search_data_for_pa_places("state='PA' src='_data'")
+  end
+
+  context "filtering data by location (src filter first)" do
+    search_data_for_pa_places("src='_data' state='PA'")
   end
 
   context "by default look for locations on current page" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,4 +53,40 @@ RSpec.configure do |config|
       { :site => site, :page => page }.merge(registers)
     )
   end
+
+  def finds_all_pa_locations(_options, _finder, actual)
+    expect(actual.empty?).to be_falsey
+    pa_places = ["Pittsburgh", "Philadelphia", "Naylor Observatory"]
+    pa_places.each do |title|
+      expect(actual.find { |l| l[:title] == title }).to be_a(Hash)
+    end
+  end
+
+  def ignores_non_pa_locations(_options, _finder, actual)
+    non_pa_places = [
+      "Boston",
+      "New York",
+      "Apache Point Observatory",
+      "Adams Observatory",
+      "Paris",
+      "Madrid",
+      "Not a place"
+    ]
+    non_pa_places.each do |title|
+      expect(actual.find { |l| l[:title] == title }).to be_nil
+    end
+  end
+
+  def search_data_for_pa_places(query)
+    let(:options) { Jekyll::Maps::OptionsParser.parse(query) }
+    let(:finder)  { Jekyll::Maps::LocationFinder.new(options) }
+    let(:actual)  { finder.find(site, page) }
+
+    it "ignores non-PA locations" do
+      finds_all_pa_locations(options, finder, actual)
+    end
+    it "finds all PA locations" do
+      ignores_non_pa_locations(options, finder, actual)
+    end
+  end
 end


### PR DESCRIPTION
Previously, if a matching src filter was found, the method would return
before checking other filters. This caused all filters after "src" to be
ignored.