### PR TITLE
WIP: Add Mapbox

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+## master
+
+* feature: add tag `mapbox` to display maps with Mapbox GL JS (<https://www.mapbox.com/>)
+
 ## 2.3.0 / 2018-03-17
 
 * customize popup link text (#34)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ maps:
     api_key: <YOUR_KEY>
 ```
 
+### Configure Mapbox API Key
+
+To be able to use Mapbox you need to obtain an [Access Token](https://docs.mapbox.com/help/glossary/access-token/).
+
+Once you have your Access Token you need to add it to Jekyll's `_config.yml`:
+
+```yml
+maps:
+  mapbox:
+    access_token: <YOUR_TOKEN>
+```
+
 ### Data Source
 
 First, add location information to your posts YAML front-matter:

--- a/lib/jekyll-maps.rb
+++ b/lib/jekyll-maps.rb
@@ -6,6 +6,9 @@ require "jekyll-maps/location_finder"
 require "jekyll-maps/options_parser"
 require "jekyll-maps/version"
 
+require "jekyll-maps/mapbox_api"
+require "jekyll-maps/mapbox_tag"
+
 module Jekyll
   module Maps
   end

--- a/lib/jekyll-maps/mapbox_api.js
+++ b/lib/jekyll-maps/mapbox_api.js
@@ -1,0 +1,159 @@
+/* global mapboxgl */
+/* global MarkerClusterer */
+// eslint-disable-next-line no-unused-vars
+var jekyllMapbox = (function() {
+  'use strict'
+  var clusterSettings = {}
+  var clusterReady = false
+  var mapReady = false
+  var options = {}
+  var data = []
+  var maps = []
+
+  return {
+    initializeMap: initializeMap,
+    initializeCluster: initializeCluster,
+    register: register
+  }
+
+  /**
+   * Setup Google Maps options and call renderer.
+   */
+  function initializeMap(accessToken) {
+    mapboxgl.accessToken = accessToken
+    mapReady = true
+    render()
+  }
+
+  /**
+   * Register map data to be rendered once Google Maps API is loaded.
+   *
+   * @param string id
+   * @param Array locations
+   * @param Object settings
+   */
+  function register(id, locations, options) {
+    data.push({ id: id, locations: locations, options: options })
+    render()
+  }
+
+  /**
+   * Render maps data if Google Maps API is loaded.
+   */
+  function render() {
+    if (!mapReady) return
+
+    while (data.length > 0) {
+      var item = data.pop()
+      // mapbox bounds: https://stackoverflow.com/a/35715102/1407622
+      var bounds = new mapboxgl.LngLatBounds()
+      if(item.customZoom) item.zoom = item.customZoom // mapbox takes
+      var mapOptions = Object.assign({
+        container: item.id,
+        style: 'mapbox://styles/mapbox/streets-v9'
+      }, options, item.options)
+
+      var map = new mapboxgl.Map(mapOptions)
+
+      // https://docs.mapbox.com/help/tutorials/custom-markers-gl-js/
+      // https://docs.mapbox.com/help/tutorials/add-points-pt-1/
+      var markers = item.locations.map(createMarker)
+
+      map.fitBounds(bounds)
+
+      if (mapOptions.useCluster) {
+        maps.push({ map: map, markers: markers })
+        processCluster()
+      }
+    }
+
+    function createMarker(location) {
+      debugger;
+      // make a marker for each feature and add to the map
+      var position = [location.longitude, location.latitude]; // order as in GEOJson
+      bounds.extend(position)
+
+      if (!mapOptions.showMarker) return false
+
+      // https://docs.mapbox.com/help/tutorials/custom-markers-gl-js/
+      // create a HTML element for each feature
+      var el = document.createElement('div');
+      el.className = 'marker';
+      var marker = new mapboxgl.Marker(el).setLngLat(position);
+      if (mapOptions.showMarkerPopup) {
+        var content = '<div class="map-info-window"><h5>' + location.title + '</h5>'
+        if (location.popup_html.length > 0) {
+          content += location.popup_html
+        }
+        else {
+          var imageTag =
+            location.image.length > 0 &&
+            '<img src="' + location.image + '" alt="' + location.title + '"/>'
+
+          var url = markerUrl(mapOptions.baseUrl, location.url)
+          if (url.length > 0) {
+            var linkContent = imageTag || location.url_text || 'View'
+            content += '<a href="' + url + '">' + linkContent + '</a>'
+          } else if (imageTag) {
+            content += imageTag
+          }
+        }
+        content += '</div>'
+
+        marker.setPopup(new mapboxgl.Popup({ offset: 25 }).setHTML(content))
+      }
+
+      marker.addTo(map);
+
+      return marker
+    }
+
+    function markerUrl(baseUrl, url) {
+      if (/^(https?|\/\/)/.test(url)) return url
+
+      return url.length > 0 ? baseUrl + url : ''
+    }
+  }
+
+  function initializeCluster(settings) {
+    clusterReady = true
+    clusterSettings = settings || {}
+    processCluster()
+  }
+
+  function processCluster() {
+    if (!clusterReady) return
+
+    while (maps.length > 0) {
+      var obj = maps.pop()
+      // eslint-disable-next-line no-new
+      new MarkerClusterer(obj.map, obj.markers, {
+        gridSize: clusterSettings.grid_size || 25,
+        imagePath:
+          'https://cdn.rawgit.com/googlemaps/js-marker-clusterer/gh-pages/images/m'
+      })
+    }
+  }
+})()
+/* Object.assign polyfill */
+if (typeof Object.assign !== 'function') {
+  Object.assign = function(target) {
+    'use strict'
+    if (target == null) {
+      throw new TypeError('Cannot convert undefined or null to object')
+    }
+
+    target = Object(target)
+    for (var index = 1; index < arguments.length; index++) {
+      var source = arguments[index]
+      if (source != null) {
+        for (var key in source) {
+          if (Object.prototype.hasOwnProperty.call(source, key)) {
+            target[key] = source[key]
+          }
+        }
+      }
+    }
+    return target
+  }
+}

--- a/lib/jekyll-maps/mapbox_api.js
+++ b/lib/jekyll-maps/mapbox_api.js
@@ -90,6 +90,7 @@ var jekyllMapbox = (function() {
               "icon-image": "marker-custom",
               "icon-anchor": "bottom",
               "icon-size": 0.7,
+              "icon-allow-overlap": true, // draw overlapping images (to be consistent with Google Map) when clustering is off
               // "text-field": "{title}",
               "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
               // "text-offset": [0, -1.6],

--- a/lib/jekyll-maps/mapbox_api.js
+++ b/lib/jekyll-maps/mapbox_api.js
@@ -59,7 +59,9 @@ var jekyllMapbox = (function() {
       // https://docs.mapbox.com/help/tutorials/add-points-pt-1/
       var markers = item.locations.map(createMarker)
 
-      map.fitBounds(bounds)
+      map.fitBounds(bounds, {
+        maxZoom: 12
+      })
 
       if (mapOptions.useCluster) {
         maps.push({ map: map, markers: markers })

--- a/lib/jekyll-maps/mapbox_api.js
+++ b/lib/jekyll-maps/mapbox_api.js
@@ -41,22 +41,22 @@ var jekyllMapbox = (function() {
     if (!mapReady) return
 
     while (data.length > 0) {
-      var item = data.pop()
+      let item = data.pop()
       // mapbox bounds: https://stackoverflow.com/a/35715102/1407622
-      var bounds = new mapboxgl.LngLatBounds()
+      let bounds = new mapboxgl.LngLatBounds()
       if(item.customZoom) item.zoom = item.customZoom // mapbox takes
-      var mapOptions = Object.assign({
+      let mapOptions = Object.assign({
         container: item.id,
         style: 'mapbox://styles/mapbox/streets-v9',
       }, options, item.options)
 
-      var map = new mapboxgl.Map(mapOptions)
+      let map = new mapboxgl.Map(mapOptions)
 
       // https://docs.mapbox.com/help/tutorials/custom-markers-gl-js/
       // https://docs.mapbox.com/help/tutorials/add-points-pt-1/
-      var geoJSON = {
+      let geoJSON = {
         type: "FeatureCollection",
-        features: item.locations.map(toGeoJSONFeature),
+        features: item.locations.map(location => toGeoJSONFeature(location, mapOptions, bounds)),
       };
 
       map.fitBounds(bounds, {
@@ -99,6 +99,7 @@ var jekyllMapbox = (function() {
           });
 
           /*
+
           map.addLayer({
             id: "clusters",
             type: "circle",
@@ -145,8 +146,8 @@ var jekyllMapbox = (function() {
 
           // inspect a cluster on click
           map.on('click', 'clusters', function (e) {
-            var features = map.queryRenderedFeatures(e.point, { layers: ['clusters'] });
-            var clusterId = features[0].properties.cluster_id;
+            let features = map.queryRenderedFeatures(e.point, { layers: ['clusters'] });
+            let clusterId = features[0].properties.cluster_id;
             map.getSource('features').getClusterExpansionZoom(clusterId, function (err, zoom) {
               if (err)
                 return;
@@ -165,7 +166,6 @@ var jekyllMapbox = (function() {
           map.on('mouseleave', 'clusters', function () {
             map.getCanvas().style.cursor = '';
           });
-
           */
 
           // https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/
@@ -173,8 +173,8 @@ var jekyllMapbox = (function() {
           // When a click event occurs on a feature in the places layer, open a popup at the
           // location of the feature, with description HTML from its properties.
           map.on('click', 'unclustered-point', function (e) {
-            var coordinates = e.features[0].geometry.coordinates.slice();
-            var description = e.features[0].properties.description;
+            let coordinates = e.features[0].geometry.coordinates.slice();
+            let description = e.features[0].properties.description;
 
             // Ensure that if the map is zoomed out such that multiple
             // copies of the feature are visible, the popup appears
@@ -203,12 +203,12 @@ var jekyllMapbox = (function() {
       });
     }
 
-    function toGeoJSONFeature(location) {
-      var position = [location.longitude, location.latitude]; // order as in GEOJson
+    function toGeoJSONFeature(location, mapOptions, bounds) {
+      let position = [location.longitude, location.latitude]; // order as in GEOJson
       bounds.extend(position);
       if (!mapOptions.showMarker) return false;
 
-      var feature = {
+      let feature = {
         geometry: {
           type: "Point",
           coordinates: position,
@@ -217,17 +217,17 @@ var jekyllMapbox = (function() {
       };
 
       if (mapOptions.showMarkerPopup) {
-        var url = markerUrl(mapOptions.baseUrl, location.url)
+        let url = markerUrl(mapOptions.baseUrl, location.url)
 
-        var description = `<div class="map-info-window"><h4>${location.title}</h4>`;
+        let description = `<div class="map-info-window"><h4>${location.title}</h4>`;
         if (location.popup_html.length > 0) {
           description += location.popup_html;
         } else {
-          var imageTag =
+          let imageTag =
             location.image.length > 0 &&
             '<img src="' + location.image + '" alt="' + location.title + '"/>'
           if (url.length > 0) {
-            var linkContent = imageTag || location.url_text || 'View'
+            let linkContent = imageTag || location.url_text || 'View'
             description += '<a href="' + url + '">' + linkContent + '</a>'
           } else if (imageTag) {
             description = imageTag

--- a/lib/jekyll-maps/mapbox_api.js
+++ b/lib/jekyll-maps/mapbox_api.js
@@ -60,7 +60,8 @@ var jekyllMapbox = (function() {
       };
 
       map.fitBounds(bounds, {
-        maxZoom: 12
+        maxZoom: 12,
+        padding: 30, // in px, to make markers on the top edge visible
       })
 
       map.on('load', function() {

--- a/lib/jekyll-maps/mapbox_api.js
+++ b/lib/jekyll-maps/mapbox_api.js
@@ -216,20 +216,21 @@ var jekyllMapbox = (function() {
       if (mapOptions.showMarkerPopup) {
         var url = markerUrl(mapOptions.baseUrl, location.url)
 
-        var description;
+        var description = `<div class="map-info-window"><h4>${location.title}</h4>`;
         if (location.popup_html.length > 0) {
-          description = location.popup_html;
+          description += location.popup_html;
         } else {
           var imageTag =
             location.image.length > 0 &&
             '<img src="' + location.image + '" alt="' + location.title + '"/>'
           if (url.length > 0) {
             var linkContent = imageTag || location.url_text || 'View'
-            description = '<a href="' + url + '">' + linkContent + '</a>'
+            description += '<a href="' + url + '">' + linkContent + '</a>'
           } else if (imageTag) {
             description = imageTag
           }
         }
+        description += '</div>'
         feature["properties"] = {
           title: location.title,
           url: url,

--- a/lib/jekyll-maps/mapbox_api.js
+++ b/lib/jekyll-maps/mapbox_api.js
@@ -174,8 +174,10 @@ var jekyllMapbox = (function() {
           // When a click event occurs on a feature in the places layer, open a popup at the
           // location of the feature, with description HTML from its properties.
           map.on('click', 'unclustered-point', function (e) {
-            let coordinates = e.features[0].geometry.coordinates.slice();
             let description = e.features[0].properties.description;
+            if(!description) return;
+
+            let coordinates = e.features[0].geometry.coordinates.slice();
 
             // Ensure that if the map is zoomed out such that multiple
             // copies of the feature are visible, the popup appears

--- a/lib/jekyll-maps/mapbox_api.js
+++ b/lib/jekyll-maps/mapbox_api.js
@@ -73,122 +73,130 @@ var jekyllMapbox = (function() {
           // clusterRadius: 50, // defaults to 50
         })
 
-        map.addLayer({
-          id: "unclustered-point",
-          type: "circle",
-          source: "features",
-          filter: ["!", ["has", "point_count"]],
-          paint: {
-            "circle-color": "#11b4da",
-            "circle-radius": 4,
-            "circle-stroke-width": 1,
-            "circle-stroke-color": "#fff"
-          }
-        });
+        // https://docs.mapbox.com/mapbox-gl-js/example/add-image/
+        map.loadImage('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADQAAAA0CAYAAADFeBvrAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAADwAAAA8ABA9l7mgAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAASrSURBVGiB3ZpPaFxVFMZ/Z8bGTFLQEhWhaa0lYGvcSERQZ6YjhS6iuLKxaqXVWtFFQPxTazZWK1QRl0HQ+GclJSlYsVUpVCczL41oA9JqW7FUWxVLbTWgSTCZmeMiU42a+969972p4Le93znn+zj3vXf/PPifQZJOqHmWoKwCbkRZgbAMSNeHK8C3CMeAT5mhKKP8kGT9RAxpgWYq3IPwAHCzQ94ayggpXqeVnfIBv8fVEsuQdtJEG4+g9AFXxNRyGuF5JnhVxpjxTeJtSLNkEQaAa3xzGHCUFJtkmFGf4JRPkObYgjBM8mYAVlKjrFke8wl26pBCihz9wMM+xZyh9BPQK6C2IdaGFIQcbwIbvMT5Y4AyD9masp9yObZx4c0APEiWPluyVYc0TzfKHlt+A6Ao3RLwYRQxUqCuoZUpjgBLPcVUEU7XZV3JXx9ZV3xDhU4ZZSqMFD3lJnkCdzPTKP1AgTTNUqJdSrQzSQblVuAVYNox59Wko998oR3SAgup8j1wiUPhMZQeCTgRkbuDKoPA9Q65x8nQLvuYMBHCO1RlPW5m9jNJPsoMgBQ5ToYcUHTIfylT3B1GiJpyax2KnUBZK2NM2gbIPiZo4k7gpEOdUE1GQ1pgIZCzLqNslYBf7HXNQvZzDuVph5BV2kWLadDcoQqdwALLIt8RsMtB1N8RsBOx3kZcTDPXmgbNhlKscJC0x2V58k/UY/c6BKw0DZkN1Whz0HTUgWvCEWummLWFdcg4T+cp8LM11wTlnAPb4xmqOYh066YJlztwjdrCOnTWOr04PW/xcwhnTENmQ8oxBzm3a5zd72zsbQ4BRm1mQ2UOg/W8XkI+/Aseiiz3oSy2ZJ+hbH4JGQ0JKMIBa1HKds2yyJp/Pmw1bQjPOYQcCPtEhC99lEGHQssRhsK+4v9Kv4ZWptkFXGVdJUJTuKE0u8G8sp0Hq2mhpFmWR+oq0MEUZaDgkP9Xpng3jBC9wcvxBnC/Q1GY3Q+9hjBEmhEpUgHQLhaQ4RaEHmAT0OSYd0DKbA4jRBsqcB1VDtlwDUhqx6oInVIKX5VE7lilyBfAe54iANIoi+tvMV8zIOyOMgO2pz41dhBj8ZkAFGGHDdHKkIzwCTi98ZLG2zLMZzZE+3O5Gs+A/yF6DEyTZpst2dqQjPAVystekuLhRSly3JbsdrbdRQstfAksc1XlCauzuLlwun2QMSZRtrjr8oTyuIsZ8LhOkYAh4C3XOA8MSMA7rkFe90Ok6QX7ee2Br8nwqE+glyEp8huwEaj6xEegSooNYaejYfDrECBlRlBe8o03J+YF3+tIiGEIgIt4FjgUK8dcCJ/TyvZ4KWJCsyxFOIjbIcd8+AnlBgk4FSdJvA4BEnCKFHcx+1OFLyoI6+KagQQMAcgwHwNPxkjRJyU+SkRLEknOw2szqAwSsC7OUfJcJNKhP5GhFxhziDjMDJuTMgON+HmpwGVUGQU6IqgngZukzI9J1k+2Q4AUOYtwBzAeQhsHupM2Aw0wBFDfKq9n/pVEBeFeKTvcNjigIYYApMze+unOXFNVlB4p8X6j6jYcmmOj5qhpjprm/5M/UZKH5tmqWZ66ELX+AOQZQbFUXt8bAAAAAElFTkSuQmCC', function(error, image) {
+          if (error) throw error;
+          map.addImage('marker-custom', image);
 
-        /*
-        map.addLayer({
-          id: "clusters",
-          type: "circle",
-          source: "features",
-          filter: ["has", "point_count"],
-          paint: {
-            // Use step expressions (https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-step)
-            // with three steps to implement three types of circles:
-            //   * Blue, 20px circles when point count is less than 100
-            //   * Yellow, 30px circles when point count is between 100 and 750
-            //   * Pink, 40px circles when point count is greater than or equal to 750
-            "circle-color": [
-              "step",
-              ["get", "point_count"],
-              "#51bbd6",
-              100,
-              "#f1f075",
-              750,
-              "#f28cb1"
-            ],
-            "circle-radius": [
-              "step",
-              ["get", "point_count"],
-              20,
-              100,
-              30,
-              750,
-              40
-            ]
-          }
-        })
+          map.addLayer({
+            id: "unclustered-point",
+            type: "symbol",
+            source: "features",
+            filter: ["!", ["has", "point_count"]],
+            layout: {
+              // "icon-image": "{marker-symbol}-15",
+              "icon-image": "marker-custom",
+              "icon-anchor": "bottom",
+              "icon-size": 0.7,
+              // "text-field": "{title}",
+              "text-font": ["Open Sans Semibold", "Arial Unicode MS Bold"],
+              // "text-offset": [0, -1.6],
+              // "text-anchor": "top"
+            }
+          });
 
-        map.addLayer({
-          id: "cluster-count",
-          type: "symbol",
-          source: "features",
-          filter: ["has", "point_count"],
-          layout: {
-            "text-field": "{point_count_abbreviated}",
-            "text-font": ["DIN Offc Pro Medium", "Arial Unicode MS Bold"],
-            "text-size": 12
-          }
-        });
+          /*
+          map.addLayer({
+            id: "clusters",
+            type: "circle",
+            source: "features",
+            filter: ["has", "point_count"],
+            paint: {
+              // Use step expressions (https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-step)
+              // with three steps to implement three types of circles:
+              //   * Blue, 20px circles when point count is less than 100
+              //   * Yellow, 30px circles when point count is between 100 and 750
+              //   * Pink, 40px circles when point count is greater than or equal to 750
+              "circle-color": [
+                "step",
+                ["get", "point_count"],
+                "#51bbd6",
+                100,
+                "#f1f075",
+                750,
+                "#f28cb1"
+              ],
+              "circle-radius": [
+                "step",
+                ["get", "point_count"],
+                20,
+                100,
+                30,
+                750,
+                40
+              ]
+            }
+          })
 
-        // inspect a cluster on click
-        map.on('click', 'clusters', function (e) {
-          var features = map.queryRenderedFeatures(e.point, { layers: ['clusters'] });
-          var clusterId = features[0].properties.cluster_id;
-          map.getSource('features').getClusterExpansionZoom(clusterId, function (err, zoom) {
-            if (err)
-              return;
+          map.addLayer({
+            id: "cluster-count",
+            type: "symbol",
+            source: "features",
+            filter: ["has", "point_count"],
+            layout: {
+              "text-field": "{point_count_abbreviated}",
+              "text-font": ["DIN Offc Pro Medium", "Arial Unicode MS Bold"],
+              "text-size": 12
+            }
+          });
 
-            map.easeTo({
-              center: features[0].geometry.coordinates,
-              zoom: zoom
+          // inspect a cluster on click
+          map.on('click', 'clusters', function (e) {
+            var features = map.queryRenderedFeatures(e.point, { layers: ['clusters'] });
+            var clusterId = features[0].properties.cluster_id;
+            map.getSource('features').getClusterExpansionZoom(clusterId, function (err, zoom) {
+              if (err)
+                return;
+
+              map.easeTo({
+                center: features[0].geometry.coordinates,
+                zoom: zoom
+              });
             });
           });
-        });
 
-        map.on('mouseenter', 'clusters', function () {
-          map.getCanvas().style.cursor = 'pointer';
-        });
-
-        map.on('mouseleave', 'clusters', function () {
-          map.getCanvas().style.cursor = '';
-        });
-
-        */
-
-        // https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/
-
-        // When a click event occurs on a feature in the places layer, open a popup at the
-        // location of the feature, with description HTML from its properties.
-        map.on('click', 'unclustered-point', function (e) {
-          var coordinates = e.features[0].geometry.coordinates.slice();
-          var description = e.features[0].properties.description;
-
-          // Ensure that if the map is zoomed out such that multiple
-          // copies of the feature are visible, the popup appears
-          // over the copy being pointed to.
-          while (Math.abs(e.lngLat.lng - coordinates[0]) > 180) {
-              coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
-          }
-
-          new mapboxgl.Popup()
-              .setLngLat(coordinates)
-              .setHTML(description)
-              .addTo(map);
-        });
-
-        // Change the cursor to a pointer when the mouse is over the places layer.
-        map.on('mouseenter', 'unclustered-point', function () {
+          map.on('mouseenter', 'clusters', function () {
             map.getCanvas().style.cursor = 'pointer';
-        });
+          });
 
-        // Change it back to a pointer when it leaves.
-        map.on('mouseleave', 'unclustered-point', function () {
+          map.on('mouseleave', 'clusters', function () {
             map.getCanvas().style.cursor = '';
+          });
+
+          */
+
+          // https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/
+
+          // When a click event occurs on a feature in the places layer, open a popup at the
+          // location of the feature, with description HTML from its properties.
+          map.on('click', 'unclustered-point', function (e) {
+            var coordinates = e.features[0].geometry.coordinates.slice();
+            var description = e.features[0].properties.description;
+
+            // Ensure that if the map is zoomed out such that multiple
+            // copies of the feature are visible, the popup appears
+            // over the copy being pointed to.
+            while (Math.abs(e.lngLat.lng - coordinates[0]) > 180) {
+                coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
+            }
+
+            // offset: https://bl.ocks.org/andrewharvey/60c0b1f12118bda230174ff630931278
+            new mapboxgl.Popup({offset: [0, -40]})
+                .setLngLat(coordinates)
+                .setHTML(description)
+                .addTo(map);
+          });
+
+          // Change the cursor to a pointer when the mouse is over the places layer.
+          map.on('mouseenter', 'unclustered-point', function () {
+              map.getCanvas().style.cursor = 'pointer';
+          });
+
+          // Change it back to a pointer when it leaves.
+          map.on('mouseleave', 'unclustered-point', function () {
+              map.getCanvas().style.cursor = '';
+          });
         });
-
-
-
       });
     }
 

--- a/lib/jekyll-maps/mapbox_api.js
+++ b/lib/jekyll-maps/mapbox_api.js
@@ -67,6 +67,17 @@ var jekyllMapbox = (function() {
         padding: 30, // in px, to make markers on the top edge visible
       })
 
+      // Add zoom and rotation controls to the map.
+      map.addControl(new mapboxgl.NavigationControl());
+
+      // Add geolocate control to the map.
+      map.addControl(new mapboxgl.GeolocateControl({
+        positionOptions: {
+            enableHighAccuracy: true
+        },
+        trackUserLocation: true
+      }));
+
       map.on('load', function() {
 
         map.addSource("features", {

--- a/lib/jekyll-maps/mapbox_api.js
+++ b/lib/jekyll-maps/mapbox_api.js
@@ -45,7 +45,7 @@ var jekyllMapbox = (function() {
       if(item.customZoom) item.zoom = item.customZoom // mapbox takes
       var mapOptions = Object.assign({
         container: item.id,
-        style: 'mapbox://styles/mapbox/streets-v9'
+        style: 'mapbox://styles/mapbox/streets-v9',
       }, options, item.options)
 
       var map = new mapboxgl.Map(mapOptions)

--- a/lib/jekyll-maps/mapbox_api.js
+++ b/lib/jekyll-maps/mapbox_api.js
@@ -8,6 +8,9 @@ var jekyllMapbox = (function() {
 
   const MarkerIconDefault = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADQAAAA0CAYAAADFeBvrAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAADwAAAA8ABA9l7mgAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAASrSURBVGiB3ZpPaFxVFMZ/Z8bGTFLQEhWhaa0lYGvcSERQZ6YjhS6iuLKxaqXVWtFFQPxTazZWK1QRl0HQ+GclJSlYsVUpVCczL41oA9JqW7FUWxVLbTWgSTCZmeMiU42a+969972p4Le93znn+zj3vXf/PPifQZJOqHmWoKwCbkRZgbAMSNeHK8C3CMeAT5mhKKP8kGT9RAxpgWYq3IPwAHCzQ94ayggpXqeVnfIBv8fVEsuQdtJEG4+g9AFXxNRyGuF5JnhVxpjxTeJtSLNkEQaAa3xzGHCUFJtkmFGf4JRPkObYgjBM8mYAVlKjrFke8wl26pBCihz9wMM+xZyh9BPQK6C2IdaGFIQcbwIbvMT5Y4AyD9masp9yObZx4c0APEiWPluyVYc0TzfKHlt+A6Ao3RLwYRQxUqCuoZUpjgBLPcVUEU7XZV3JXx9ZV3xDhU4ZZSqMFD3lJnkCdzPTKP1AgTTNUqJdSrQzSQblVuAVYNox59Wko998oR3SAgup8j1wiUPhMZQeCTgRkbuDKoPA9Q65x8nQLvuYMBHCO1RlPW5m9jNJPsoMgBQ5ToYcUHTIfylT3B1GiJpyax2KnUBZK2NM2gbIPiZo4k7gpEOdUE1GQ1pgIZCzLqNslYBf7HXNQvZzDuVph5BV2kWLadDcoQqdwALLIt8RsMtB1N8RsBOx3kZcTDPXmgbNhlKscJC0x2V58k/UY/c6BKw0DZkN1Whz0HTUgWvCEWummLWFdcg4T+cp8LM11wTlnAPb4xmqOYh066YJlztwjdrCOnTWOr04PW/xcwhnTENmQ8oxBzm3a5zd72zsbQ4BRm1mQ2UOg/W8XkI+/Aseiiz3oSy2ZJ+hbH4JGQ0JKMIBa1HKds2yyJp/Pmw1bQjPOYQcCPtEhC99lEGHQssRhsK+4v9Kv4ZWptkFXGVdJUJTuKE0u8G8sp0Hq2mhpFmWR+oq0MEUZaDgkP9Xpng3jBC9wcvxBnC/Q1GY3Q+9hjBEmhEpUgHQLhaQ4RaEHmAT0OSYd0DKbA4jRBsqcB1VDtlwDUhqx6oInVIKX5VE7lilyBfAe54iANIoi+tvMV8zIOyOMgO2pz41dhBj8ZkAFGGHDdHKkIzwCTi98ZLG2zLMZzZE+3O5Gs+A/yF6DEyTZpst2dqQjPAVystekuLhRSly3JbsdrbdRQstfAksc1XlCauzuLlwun2QMSZRtrjr8oTyuIsZ8LhOkYAh4C3XOA8MSMA7rkFe90Ok6QX7ee2Br8nwqE+glyEp8huwEaj6xEegSooNYaejYfDrECBlRlBe8o03J+YF3+tIiGEIgIt4FjgUK8dcCJ/TyvZ4KWJCsyxFOIjbIcd8+AnlBgk4FSdJvA4BEnCKFHcx+1OFLyoI6+KagQQMAcgwHwNPxkjRJyU+SkRLEknOw2szqAwSsC7OUfJcJNKhP5GhFxhziDjMDJuTMgON+HmpwGVUGQU6IqgngZukzI9J1k+2Q4AUOYtwBzAeQhsHupM2Aw0wBFDfKq9n/pVEBeFeKTvcNjigIYYApMze+unOXFNVlB4p8X6j6jYcmmOj5qhpjprm/5M/UZKH5tmqWZ66ELX+AOQZQbFUXt8bAAAAAElFTkSuQmCC'
 
+  // source: https://github.com/googlemaps/js-marker-clusterer/blob/gh-pages/images/m1.png
+  const ClusterIconDefault = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADUAAAA0CAYAAAAqunDVAAAABHNCSVQICAgIfAhkiAAAEDpJREFUaEO1WmtwXddV/s7jvq8kS34raus0dkjsjDFODLQUGlJoGUiBIYQJMEOHDvQHoT8SEr8a8A1tEr+mnSkzMLRMytAfgSYzZNoGZmDalLSFadwkNMZJGzuxHcu2HMmS9bj33HvPY/Ottc+RZOVKlmx5a67uuefsvfb69nrutY+D69FqxsUxONgCD+P8YBBYO5CHM5JgaFWEHhjgOxGODRtsec2gVkuWkw1n2YjVThaBFfLxkRMgDRem7PKaABrpNGV+yzW/w8CBU0oQTsXIV2O0R0Oc6wvwJSe8Vp6uFZSDmqmQxyoMQQizUcPAL1u6ek2JaRNA0lKAEcF26hcnIc4PTeBvNrXSAUv+ujpQtRoB7KuiXC/DVHjNJgCE8QxEmIJx6pE+dyoJpeagzY/9pjQDIGc4Tlq2IHweOg7cuI12tY6ak4nZdlvE/6WDeuBMCesHxCoIhvNFZateGRj5HY7WgVcbqP2yBTQfI58+XkD/xjLcRmmmyyxwSrtOFa1cJLiFac2aY/GgVDoPrICfK8Ex1rAVCJlwESEZCfDDVQ2sO+Ero6A7QNgLL0fVRB5JZCXi+g5/B4jbEzDxGKJgEuhr4Bxp3ThehecXYJxU+gTlNyyPbnkcDztcrCu3xYH61A9z2HR7L5KGbyVDwgLI4So2Kpe4ik0cMP3CFp9UgDivkjTiJNg8alocW26ya47WG45H64paBHMJ8cgb2LV6krS6EKJbncxsu4zLLex1RjkqVVlLcu7/K4MSQDfduvoyJyBG7qKJPbiEx7CGALeScIUrHysUx3PeBULAZE0Aym8T277ynRCkR0qxuYDm2KvA6gbyUyvhVXM6LAMX0NZq3Rd5Z15gVwZVM1WUuGqZV1PpHH6HjqIbxWgzPIeAvWRaKkksMvDgelzlaBw5v07nMMk7lomonUM+30UuK0icbvaLuQCJBSlUYlfvmfAszuRehz/oYuVAH3KpIxI+wvLwQjZ2ZVCySrWL3Sj1VRHVY3ymegGHzI1k5DZdwdmSsddTaOFNPOIw4qZADk6tg/FpY7SV4MSbqG2RWMSg+7yP/J3vhx9v5MK4kAXJaIrkXNPCOxe/j+raFkFZbRk6MXold784UDJRzdD4H22isuc2JN4GTmmdhaoNJRWHg2jmjtMOuuBGW+D7t5Ht9xL0OiRJzF5WUoYyo9PmaII2pwnmKKm/jmAih1LpZri5tfxtJS8glXbzKJpFascp8nFjU4Ev0BYPSog8EWyAW9xGpqx7FVVJzBRO+t/FTVxJt/zH7LWOz/PTcyYJ7c+9fJ4kzYpcOjn7vEkpvYoT3lexgaru4+dUhcXRiDKbKERj7HuorZlaAMv0o6WBkmEHWrfCeFQXNs87ibdxHAPxx3j9ccQEkEmQukYw4ppFKUOYRMKuzMeYxNuGfUUimYq6rvg6uvnwqzhPW7oBO/i7lzZGVfVexk5nSOdcRFs6KCH6uLkFCeNLFAaoVO+nqWzgXcaqVCpJkiegcTL1ImL8CM2pYWYPDRR9ql6BLj83QEa3E+IO9hNpRaRBuSR2IZL4f7DTfxKPtzaj3RxCrUfc+KLb1YES8ppZ9B8iU7LCliFZddcd49Nn8JDzEpm6hZ7uLkpwE/3Ah2EMV9t5k8+/C1N/AUf+bRg7fue3ee8XOI5g2Wxs8/l9ltLZt2gkszpePSghctDczdX+Ta60aFSAxH2KinYGBdxP7u5hj5un52I6p01SPbm2398j809SCZ+hBX2M4D8qFsRPE6H7dwy0P54ev4SLawMlEx2M7mFa8yEE7j5mTB8kt/8K12GqYyztDMxspowmsbSwFBwolZbzAXjhOuRyf4KkdRg7i8eXgOOyrtcOSsg9cakXuR5KB59NqVumF8eV7WvoReHch/pr/8k41l7c0M69bOLY+dni77pdn6RkBJCNRSKFxbdMolWO+iYqm39m8UM797QEJb/rn2SEv5NJmZMx1nnE3LuHot+iQT2rgJxOujZ3wAK/RS0dbjHC5s3YUzq1QM8FH/n6tP/mHuS6cjhEBxyPttDs5XaAAVSy74WaZObAl1O5LEU6nanaRcnBLz7KDp/o3Gmeu7VjeZQ2F+iuQtmOSx1hNaO4TaPNmN2zeL13cnidnukMM7m30P9ojNo+cV0zkjwQ/wVd9eF5prn62+JH2o11mmd2asLzxRM5vGfjAN3+m4ybq+E1bDYflJu+Vn22SYhnk2JI1BvAD9iJv+O4xO/NDJRvobzvXhzmxi8OT7Lj69hVHqSX+2SnOa/pnlVBB4XKF0jnD5TWQ0MVrO29iXZbR6Mwzk3OVpQ2djPb8PGAOcddQIhSmaC4Ey8j77KMJZFB9q5WAjWnDa+0RlNKaYmZsBWeZCvv3MHN3O/y+Uewf5RZtwBe5iYqaMsWv6+UD8R/jbWrD9Ia/pyZyK+hNNLSxXZpKq4XYmVzDTDMXDQtLUj4Z10up3sV2cnmmU1L44ZghlWujjTHvUHhS2iMopPwun9jps8yX2Xxa3+LlUOXOiMf2Ua6W7BrlSS1aUZMdovFCi6OhyqUtE5CtZNtT9qYdupVxA2cpKG6O6XpHWIZzCSe5naan1F6xvspDZ7Xqykwl3sojHJel0vJG5y/NsqtTVqBEm1KUMTKjeRbyiK2dY5Trm+mt+Ox4S5UthNukm4hWtwKjHACZtAzPuO6YNMiTXzBAspm8K3Hnp4wq33OVNI6g8oGaC0hzy1dXUSeiYUG6XXx19R1lZTwINrCgiH/z6xevnse9bhMUtwFaCNSKTJqS0tson5OWFDXSqXTxFWmcpjbwaXErrOk4iiheokt8zvdf+11LrK2kfIppiae/DV+ZksqOjFTnM/qbY4/riJXSeXsEhiM6d5H9j2Ouxlh66lUUtcDGWVDsqZ+lI6ioGqvJTeX5ThTlGXVtXelptEax3i3jbF6U1Z95WDM6gw9mlRWuQJSDAF9YhqLSYyVHzaDN7g1IHFZMW8T9moWzbrxtFpqt2VpmuE7P4HTI66Ahw5s4gVdbjjzyk9qNlKsKYyghzFKPJ+Wvhvy8L/oKlnvlptS1566tcD73OhRSlLmksKkZOFJ9IZKTyWFTahNrqZK/MOygJhLxGrXn8GJtnOOktqUVHmbwQ/YdeV0XVEgNx+dRL6POkiFEgxBue1q6hNWbHwS4tUyawinGsyGmgoiYQ0O5Y20Lck90nuJbOM/QfX8CkeIbS2vCibmKEvM34br/zrntGEEGMIj5TNkXKpNlBw1zqO7l7MtOTyabqMEJblcYZyMS0QmAb+LTmBDRII2mXVYaPTdfgyVpCo6os7Ccenmk42I4ksE9FyanS8HMLEl8uI8hAPhrxLQKs4pdMUPcp/F+iMNRuUmpbmQQVZ2GO3Amz51wVDT6marYc+C5LxIKg5TFwqIWxfUUWgJmSTWtwb4+1kCKhKQXZdC/g/xsCvb9v/mZx5XO7OGC15lu2FjvgATvMZFvYcL2OJ8hOTWEY8fQbVvG3lhkUb/xGQuoP/2LuRK9qxLK1lPRxZUrV8zQW0irb5KGcH+4xQxMyyxLVmbwnuxO/8jTvR/7CXeRmxrAw7G9+Ps4K9wheW+bUtTR+vpNOdLnsARdzdQ+JSyLQulmQx+gFaPLO4KiObYwwaeglC9/KA0nbdGk6Go40zwDWgv2ojPuDZqR62jJKvKS2BVPNa6DcGlv+ePSV1BVsv5fTv6+/+IAfouZjFfVxI2Kb2yOlpTJPvk3+CvUK9/Hj+bfJqe7gZVMYcez3Hf4vbiKRSirQpI6YtB1Vm+picUKWmM4me0oRhmQIEnGPJAPIgmhg/2obX/FD3gRLpqtK38+1ka7ubvf+HYLF1pc/rtyLH+d/7sfbSzuym1IAWmPLyrZZK0Xu4Vupp+1hG/gkrXLkplM+lluc84pfO3Wv9z/W6lY6g9LtVuZ3WIpmKlJGYjIenwOk2+Z0DVHEZtFielSQd1GPvyJHrCEpOV40q5pZ/G8ZdeZqd/tvcZu2Sdk6SfJ4yf5+UY3nYYAuL7ePdbfHaMIM/yelA/UjlynP+lWn2Ne7MdOI0P8ICARc3C57hYdATMMS1fLYTtL/NQrsra4S06tzgHqdi+yD/Z+sjGVgVAYYTDslvXdrlx10ye25CV+kQ6y4mhHNuU9m1n9BaVEJch95sIHvsWKvt2MLH9U/WGWXVWArRLLwmye+7cP6FnwON6rpDCs9KVVCw4P4rq+i2k9fO8cyNpSEAVMKJ0lATVu10/iJD6WSwRMJ2VxE1xWq3mq7hQHMIAvaCqHZscfu/tYhXYtstByb2a6UOpUbTSEgZoazWe3h0yd/HpTHIptlYffR5+H/U6eZB2UE3dvTgQoRsw5f0cxwrAy5u8nlDZsIu9+hWGNBmjrjo5jeHhL2JFdx8K+e20Z2tHsphJeB578kfwmFk/DUgcXHhqbPZpyGybshMLALdsMwxJOwRgzXRT5VgqpvbrGZLGau5ken4RXquEIfcR2tKzfC7ZfFHBJck7vJ6wROf81+OY+Jz2s6pW0v5J+I8IPnsAa/o2oVDaTvuRbQ+Bcs44vKCAahOrrMqlGUQ40Zp7vPNuUDLN8Zd4wCx5lDQOLtHz3fS+IqX9bbp5lpdlVXmkKQx5hVuwLvoQHB61BO7DfPIk79epom9TSvMXJR2PuR2lbZLz7H8IO72/RBidQemRu+0BgqqjlaDnXcLe3ItaYCl1cVcuDo0H3BEDdYfDg86gvnRHiLFJ7m75xoqA0/pFuYvKV8CLTz8PJxlWt6r7HUrNOEw6V32EMvogWvWfkMEHUT/zjDI1X4tHXkHY2IOdbo0kJnAw/DDd8w7StWB0HGnHPGl7yHkBj0/2acVIeMk+p3/c8TTk3TY1mwk9JQ/owvm6jTgOIabi7hnDE+Z9BLXNHl4z8c2ONmW8nP497Dw3H57p+4fNL1FtK+xvw4MGetLSbQY1oel9n30v2RJeg6mQvFfBZgI69bMj8x2TdpZUNusuZxJ+c8oCStWx5BfpNFbjZdYDg/P/QSa4WnS34pmkybeJGPMW0SLuBjxm31aVraqxQELFO4Pd/jdwkWpcYinBTwHpOxVUvQUAyawLg5Ieu/vGMTQ4pqqo0uJqyfsU2/iqAdbnsZN5X8IVjdpv6Sork+HpRUASB87YRSnJR/TA8Y6h4b+A1neOqkPI3LbGTbEhfg+Vl/EgW165ec96Fltmv41CVqQA6pemsNsRT2fU3X7GEeNfTHOwv70VzdZ51Lrewb3Gw5YJBtXukpbtFAznkBZMscZQHaHzmWVznadY2Kbmjrn3ax62f5RRv4d7LqpBVgDVieklY7r8NlXmSjX42XSF5h33ljm2SCnPvAiSbfq078gk34SRcJF65LmMXf57aaCysVInKNdXzLxBxsmyd4iC8hRBdY5PnXiRdEfPgdOWqZou0lSIV/59FE//ngbGxbY5NbRFDrOSGNIip5gya7w6Ur3TqfljUyfyzd5Q93DZokifIJJsm2+hdS186tKJHu9dHaiMmH2ri+rGYo1/J98uowodO7LUNyu5CFRleedofLyOwefaS5XMXGz/D6uH1Ic5XLquAAAAAElFTkSuQmCC'
+
   return {
     initializeMap: initializeMap,
     register: register
@@ -70,8 +73,6 @@ var jekyllMapbox = (function() {
           type: "geojson",
           data: geoJSON,
           cluster: mapOptions.useCluster,
-          clusterMaxZoom: 14,
-          clusterRadius: 50, // defaults to 50
         })
 
         // https://docs.mapbox.com/mapbox-gl-js/example/add-image/
@@ -99,63 +100,61 @@ var jekyllMapbox = (function() {
           });
 
           if(mapOptions.useCluster) {
-            map.addLayer({
-              id: "clusters",
-              type: "circle",
-              source: "features",
-              filter: ["has", "point_count"],
-              paint: {
-                // with three steps to implement three types of circles:
-                //   * Blue, 20px circles when point count is less than 100
-                //   * Yellow, 30px circles when point count is between 100 and 750
-                //   * Pink, 40px circles when point count is greater than or equal to 750
-                "circle-color": "#ff3d00",
-                // Use step expressions (https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-step)
-                "circle-radius": [
-                  "step",
-                  ["get", "point_count"],
-                  20,
-                  100,
-                  30,
-                  750,
-                  40
-                ],
-              },
-            })
+            map.loadImage(ClusterIconDefault, function(error, image) {
+              if (error) throw error;
+              map.addImage('cluster-custom', image);
 
-            map.addLayer({
-              id: "cluster-count",
-              type: "symbol",
-              source: "features",
-              filter: ["has", "point_count"],
-              layout: {
-                "text-field": "{point_count_abbreviated}",
-                "text-font": ["DIN Offc Pro Medium", "Arial Unicode MS Bold"],
-                "text-size": 12
-              }
-            });
+              map.addLayer({
+                id: "clusters",
+                type: "symbol",
+                source: "features",
+                filter: ["has", "point_count"],
+                layout: {
+                  "icon-image": "cluster-custom",
+                  "icon-allow-overlap": true,
+                  "text-allow-overlap": true,
+                  "text-ignore-placement": true,
+                }
 
-            // inspect a cluster on click
-            map.on('click', 'clusters', function (e) {
-              let features = map.queryRenderedFeatures(e.point, { layers: ['clusters'] });
-              let clusterId = features[0].properties.cluster_id;
-              map.getSource('features').getClusterExpansionZoom(clusterId, function (err, zoom) {
-                if (err)
-                  return;
+              })
 
-                map.easeTo({
-                  center: features[0].geometry.coordinates,
-                  zoom: zoom
+              map.addLayer({
+                id: "cluster-count",
+                type: "symbol",
+                source: "features",
+                filter: ["has", "point_count"],
+                layout: {
+                  "text-field": "{point_count_abbreviated}",
+                  "text-font": ["DIN Offc Pro Medium", "Arial Unicode MS Bold"],
+                  "text-size": 12,
+                  "icon-allow-overlap": true,
+                  "text-allow-overlap": true,
+                  "text-ignore-placement": true,
+                }
+              });
+
+              // inspect a cluster on click
+              map.on('click', 'clusters', function (e) {
+                let features = map.queryRenderedFeatures(e.point, { layers: ['clusters'] });
+                let clusterId = features[0].properties.cluster_id;
+                map.getSource('features').getClusterExpansionZoom(clusterId, function (err, zoom) {
+                  if (err)
+                    return;
+
+                  map.easeTo({
+                    center: features[0].geometry.coordinates,
+                    zoom: zoom
+                  });
                 });
               });
-            });
 
-            map.on('mouseenter', 'clusters', function () {
-              map.getCanvas().style.cursor = 'pointer';
-            });
+              map.on('mouseenter', 'clusters', function () {
+                map.getCanvas().style.cursor = 'pointer';
+              });
 
-            map.on('mouseleave', 'clusters', function () {
-              map.getCanvas().style.cursor = '';
+              map.on('mouseleave', 'clusters', function () {
+                map.getCanvas().style.cursor = '';
+              });
             });
           }
 

--- a/lib/jekyll-maps/mapbox_api.js
+++ b/lib/jekyll-maps/mapbox_api.js
@@ -1,18 +1,13 @@
 /* global mapboxgl */
-/* global MarkerClusterer */
 // eslint-disable-next-line no-unused-vars
 var jekyllMapbox = (function() {
   'use strict'
-  var clusterSettings = {}
-  var clusterReady = false
   var mapReady = false
   var options = {}
   var data = []
-  var maps = []
 
   return {
     initializeMap: initializeMap,
-    initializeCluster: initializeCluster,
     register: register
   }
 
@@ -57,82 +52,193 @@ var jekyllMapbox = (function() {
 
       // https://docs.mapbox.com/help/tutorials/custom-markers-gl-js/
       // https://docs.mapbox.com/help/tutorials/add-points-pt-1/
-      var markers = item.locations.map(createMarker)
+      var geoJSON = {
+        type: "FeatureCollection",
+        features: item.locations.map(toGeoJSONFeature),
+      };
 
       map.fitBounds(bounds, {
         maxZoom: 12
       })
 
-      if (mapOptions.useCluster) {
-        maps.push({ map: map, markers: markers })
-        processCluster()
-      }
+      map.on('load', function() {
+
+        console.log(geoJSON);
+
+        map.addSource("features", {
+          type: "geojson",
+          data: geoJSON,
+          // cluster: true,
+          // clusterMaxZoom: 14,
+          // clusterRadius: 50, // defaults to 50
+        })
+
+        map.addLayer({
+          id: "unclustered-point",
+          type: "circle",
+          source: "features",
+          filter: ["!", ["has", "point_count"]],
+          paint: {
+            "circle-color": "#11b4da",
+            "circle-radius": 4,
+            "circle-stroke-width": 1,
+            "circle-stroke-color": "#fff"
+          }
+        });
+
+        /*
+        map.addLayer({
+          id: "clusters",
+          type: "circle",
+          source: "features",
+          filter: ["has", "point_count"],
+          paint: {
+            // Use step expressions (https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-step)
+            // with three steps to implement three types of circles:
+            //   * Blue, 20px circles when point count is less than 100
+            //   * Yellow, 30px circles when point count is between 100 and 750
+            //   * Pink, 40px circles when point count is greater than or equal to 750
+            "circle-color": [
+              "step",
+              ["get", "point_count"],
+              "#51bbd6",
+              100,
+              "#f1f075",
+              750,
+              "#f28cb1"
+            ],
+            "circle-radius": [
+              "step",
+              ["get", "point_count"],
+              20,
+              100,
+              30,
+              750,
+              40
+            ]
+          }
+        })
+
+        map.addLayer({
+          id: "cluster-count",
+          type: "symbol",
+          source: "features",
+          filter: ["has", "point_count"],
+          layout: {
+            "text-field": "{point_count_abbreviated}",
+            "text-font": ["DIN Offc Pro Medium", "Arial Unicode MS Bold"],
+            "text-size": 12
+          }
+        });
+
+        // inspect a cluster on click
+        map.on('click', 'clusters', function (e) {
+          var features = map.queryRenderedFeatures(e.point, { layers: ['clusters'] });
+          var clusterId = features[0].properties.cluster_id;
+          map.getSource('features').getClusterExpansionZoom(clusterId, function (err, zoom) {
+            if (err)
+              return;
+
+            map.easeTo({
+              center: features[0].geometry.coordinates,
+              zoom: zoom
+            });
+          });
+        });
+
+        map.on('mouseenter', 'clusters', function () {
+          map.getCanvas().style.cursor = 'pointer';
+        });
+
+        map.on('mouseleave', 'clusters', function () {
+          map.getCanvas().style.cursor = '';
+        });
+
+        */
+
+        // https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/
+
+        // When a click event occurs on a feature in the places layer, open a popup at the
+        // location of the feature, with description HTML from its properties.
+        map.on('click', 'unclustered-point', function (e) {
+          var coordinates = e.features[0].geometry.coordinates.slice();
+          var description = e.features[0].properties.description;
+
+          // Ensure that if the map is zoomed out such that multiple
+          // copies of the feature are visible, the popup appears
+          // over the copy being pointed to.
+          while (Math.abs(e.lngLat.lng - coordinates[0]) > 180) {
+              coordinates[0] += e.lngLat.lng > coordinates[0] ? 360 : -360;
+          }
+
+          new mapboxgl.Popup()
+              .setLngLat(coordinates)
+              .setHTML(description)
+              .addTo(map);
+        });
+
+        // Change the cursor to a pointer when the mouse is over the places layer.
+        map.on('mouseenter', 'unclustered-point', function () {
+            map.getCanvas().style.cursor = 'pointer';
+        });
+
+        // Change it back to a pointer when it leaves.
+        map.on('mouseleave', 'unclustered-point', function () {
+            map.getCanvas().style.cursor = '';
+        });
+
+
+
+      });
     }
 
-    function createMarker(location) {
-      // make a marker for each feature and add to the map
+    function toGeoJSONFeature(location) {
       var position = [location.longitude, location.latitude]; // order as in GEOJson
-      bounds.extend(position)
+      bounds.extend(position);
+      if (!mapOptions.showMarker) return false;
 
-      if (!mapOptions.showMarker) return false
+      var feature = {
+        geometry: {
+          type: "Point",
+          coordinates: position,
+        },
+        type: "Feature",
+      };
 
-      // https://docs.mapbox.com/help/tutorials/custom-markers-gl-js/
-      // create a HTML element for each feature
-      var el = document.createElement('div');
-      el.className = 'marker';
-      var marker = new mapboxgl.Marker(el).setLngLat(position);
       if (mapOptions.showMarkerPopup) {
-        var content = '<div class="map-info-window"><h5>' + location.title + '</h5>'
+        var url = markerUrl(mapOptions.baseUrl, location.url)
+
+        var description;
         if (location.popup_html.length > 0) {
-          content += location.popup_html
-        }
-        else {
+          description = location.popup_html;
+        } else {
           var imageTag =
             location.image.length > 0 &&
             '<img src="' + location.image + '" alt="' + location.title + '"/>'
-
-          var url = markerUrl(mapOptions.baseUrl, location.url)
           if (url.length > 0) {
             var linkContent = imageTag || location.url_text || 'View'
-            content += '<a href="' + url + '">' + linkContent + '</a>'
+            description = '<a href="' + url + '">' + linkContent + '</a>'
           } else if (imageTag) {
-            content += imageTag
+            description = imageTag
           }
         }
-        content += '</div>'
-
-        marker.setPopup(new mapboxgl.Popup({ offset: 25 }).setHTML(content))
+        feature["properties"] = {
+          title: location.title,
+          url: url,
+          url_text: location.url_text,
+          image: location.image,
+          popup_html: location.popup_html,
+          description: description,
+        };
       }
 
-      marker.addTo(map);
-
-      return marker
+      return feature;
     }
 
     function markerUrl(baseUrl, url) {
       if (/^(https?|\/\/)/.test(url)) return url
 
       return url.length > 0 ? baseUrl + url : ''
-    }
-  }
-
-  function initializeCluster(settings) {
-    clusterReady = true
-    clusterSettings = settings || {}
-    processCluster()
-  }
-
-  function processCluster() {
-    if (!clusterReady) return
-
-    while (maps.length > 0) {
-      var obj = maps.pop()
-      // eslint-disable-next-line no-new
-      new MarkerClusterer(obj.map, obj.markers, {
-        gridSize: clusterSettings.grid_size || 25,
-        imagePath:
-          'https://cdn.rawgit.com/googlemaps/js-marker-clusterer/gh-pages/images/m'
-      })
     }
   }
 })()

--- a/lib/jekyll-maps/mapbox_api.js
+++ b/lib/jekyll-maps/mapbox_api.js
@@ -69,7 +69,7 @@ var jekyllMapbox = (function() {
         map.addSource("features", {
           type: "geojson",
           data: geoJSON,
-          cluster: true,
+          cluster: mapOptions.useCluster,
           clusterMaxZoom: 14,
           clusterRadius: 50, // defaults to 50
         })
@@ -98,64 +98,66 @@ var jekyllMapbox = (function() {
             }
           });
 
-          map.addLayer({
-            id: "clusters",
-            type: "circle",
-            source: "features",
-            filter: ["has", "point_count"],
-            paint: {
-              // with three steps to implement three types of circles:
-              //   * Blue, 20px circles when point count is less than 100
-              //   * Yellow, 30px circles when point count is between 100 and 750
-              //   * Pink, 40px circles when point count is greater than or equal to 750
-              "circle-color": "#ff3d00",
-              // Use step expressions (https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-step)
-              "circle-radius": [
-                "step",
-                ["get", "point_count"],
-                20,
-                100,
-                30,
-                750,
-                40
-              ],
-            },
-          })
+          if(mapOptions.useCluster) {
+            map.addLayer({
+              id: "clusters",
+              type: "circle",
+              source: "features",
+              filter: ["has", "point_count"],
+              paint: {
+                // with three steps to implement three types of circles:
+                //   * Blue, 20px circles when point count is less than 100
+                //   * Yellow, 30px circles when point count is between 100 and 750
+                //   * Pink, 40px circles when point count is greater than or equal to 750
+                "circle-color": "#ff3d00",
+                // Use step expressions (https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-step)
+                "circle-radius": [
+                  "step",
+                  ["get", "point_count"],
+                  20,
+                  100,
+                  30,
+                  750,
+                  40
+                ],
+              },
+            })
 
-          map.addLayer({
-            id: "cluster-count",
-            type: "symbol",
-            source: "features",
-            filter: ["has", "point_count"],
-            layout: {
-              "text-field": "{point_count_abbreviated}",
-              "text-font": ["DIN Offc Pro Medium", "Arial Unicode MS Bold"],
-              "text-size": 12
-            }
-          });
+            map.addLayer({
+              id: "cluster-count",
+              type: "symbol",
+              source: "features",
+              filter: ["has", "point_count"],
+              layout: {
+                "text-field": "{point_count_abbreviated}",
+                "text-font": ["DIN Offc Pro Medium", "Arial Unicode MS Bold"],
+                "text-size": 12
+              }
+            });
 
-          // inspect a cluster on click
-          map.on('click', 'clusters', function (e) {
-            let features = map.queryRenderedFeatures(e.point, { layers: ['clusters'] });
-            let clusterId = features[0].properties.cluster_id;
-            map.getSource('features').getClusterExpansionZoom(clusterId, function (err, zoom) {
-              if (err)
-                return;
+            // inspect a cluster on click
+            map.on('click', 'clusters', function (e) {
+              let features = map.queryRenderedFeatures(e.point, { layers: ['clusters'] });
+              let clusterId = features[0].properties.cluster_id;
+              map.getSource('features').getClusterExpansionZoom(clusterId, function (err, zoom) {
+                if (err)
+                  return;
 
-              map.easeTo({
-                center: features[0].geometry.coordinates,
-                zoom: zoom
+                map.easeTo({
+                  center: features[0].geometry.coordinates,
+                  zoom: zoom
+                });
               });
             });
-          });
 
-          map.on('mouseenter', 'clusters', function () {
-            map.getCanvas().style.cursor = 'pointer';
-          });
+            map.on('mouseenter', 'clusters', function () {
+              map.getCanvas().style.cursor = 'pointer';
+            });
 
-          map.on('mouseleave', 'clusters', function () {
-            map.getCanvas().style.cursor = '';
-          });
+            map.on('mouseleave', 'clusters', function () {
+              map.getCanvas().style.cursor = '';
+            });
+          }
 
           // https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/
 

--- a/lib/jekyll-maps/mapbox_api.js
+++ b/lib/jekyll-maps/mapbox_api.js
@@ -69,9 +69,9 @@ var jekyllMapbox = (function() {
         map.addSource("features", {
           type: "geojson",
           data: geoJSON,
-          // cluster: true,
-          // clusterMaxZoom: 14,
-          // clusterRadius: 50, // defaults to 50
+          cluster: true,
+          clusterMaxZoom: 14,
+          clusterRadius: 50, // defaults to 50
         })
 
         // https://docs.mapbox.com/mapbox-gl-js/example/add-image/
@@ -98,28 +98,18 @@ var jekyllMapbox = (function() {
             }
           });
 
-          /*
-
           map.addLayer({
             id: "clusters",
             type: "circle",
             source: "features",
             filter: ["has", "point_count"],
             paint: {
-              // Use step expressions (https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-step)
               // with three steps to implement three types of circles:
               //   * Blue, 20px circles when point count is less than 100
               //   * Yellow, 30px circles when point count is between 100 and 750
               //   * Pink, 40px circles when point count is greater than or equal to 750
-              "circle-color": [
-                "step",
-                ["get", "point_count"],
-                "#51bbd6",
-                100,
-                "#f1f075",
-                750,
-                "#f28cb1"
-              ],
+              "circle-color": "#ff3d00",
+              // Use step expressions (https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-step)
               "circle-radius": [
                 "step",
                 ["get", "point_count"],
@@ -128,8 +118,8 @@ var jekyllMapbox = (function() {
                 30,
                 750,
                 40
-              ]
-            }
+              ],
+            },
           })
 
           map.addLayer({
@@ -166,7 +156,6 @@ var jekyllMapbox = (function() {
           map.on('mouseleave', 'clusters', function () {
             map.getCanvas().style.cursor = '';
           });
-          */
 
           // https://docs.mapbox.com/mapbox-gl-js/example/popup-on-click/
 

--- a/lib/jekyll-maps/mapbox_api.js
+++ b/lib/jekyll-maps/mapbox_api.js
@@ -68,7 +68,6 @@ var jekyllMapbox = (function() {
     }
 
     function createMarker(location) {
-      debugger;
       // make a marker for each feature and add to the map
       var position = [location.longitude, location.latitude]; // order as in GEOJson
       bounds.extend(position)

--- a/lib/jekyll-maps/mapbox_api.js
+++ b/lib/jekyll-maps/mapbox_api.js
@@ -6,6 +6,8 @@ var jekyllMapbox = (function() {
   var options = {}
   var data = []
 
+  const MarkerIconDefault = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADQAAAA0CAYAAADFeBvrAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAADwAAAA8ABA9l7mgAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAASrSURBVGiB3ZpPaFxVFMZ/Z8bGTFLQEhWhaa0lYGvcSERQZ6YjhS6iuLKxaqXVWtFFQPxTazZWK1QRl0HQ+GclJSlYsVUpVCczL41oA9JqW7FUWxVLbTWgSTCZmeMiU42a+969972p4Le93znn+zj3vXf/PPifQZJOqHmWoKwCbkRZgbAMSNeHK8C3CMeAT5mhKKP8kGT9RAxpgWYq3IPwAHCzQ94ayggpXqeVnfIBv8fVEsuQdtJEG4+g9AFXxNRyGuF5JnhVxpjxTeJtSLNkEQaAa3xzGHCUFJtkmFGf4JRPkObYgjBM8mYAVlKjrFke8wl26pBCihz9wMM+xZyh9BPQK6C2IdaGFIQcbwIbvMT5Y4AyD9masp9yObZx4c0APEiWPluyVYc0TzfKHlt+A6Ao3RLwYRQxUqCuoZUpjgBLPcVUEU7XZV3JXx9ZV3xDhU4ZZSqMFD3lJnkCdzPTKP1AgTTNUqJdSrQzSQblVuAVYNox59Wko998oR3SAgup8j1wiUPhMZQeCTgRkbuDKoPA9Q65x8nQLvuYMBHCO1RlPW5m9jNJPsoMgBQ5ToYcUHTIfylT3B1GiJpyax2KnUBZK2NM2gbIPiZo4k7gpEOdUE1GQ1pgIZCzLqNslYBf7HXNQvZzDuVph5BV2kWLadDcoQqdwALLIt8RsMtB1N8RsBOx3kZcTDPXmgbNhlKscJC0x2V58k/UY/c6BKw0DZkN1Whz0HTUgWvCEWummLWFdcg4T+cp8LM11wTlnAPb4xmqOYh066YJlztwjdrCOnTWOr04PW/xcwhnTENmQ8oxBzm3a5zd72zsbQ4BRm1mQ2UOg/W8XkI+/Aseiiz3oSy2ZJ+hbH4JGQ0JKMIBa1HKds2yyJp/Pmw1bQjPOYQcCPtEhC99lEGHQssRhsK+4v9Kv4ZWptkFXGVdJUJTuKE0u8G8sp0Hq2mhpFmWR+oq0MEUZaDgkP9Xpng3jBC9wcvxBnC/Q1GY3Q+9hjBEmhEpUgHQLhaQ4RaEHmAT0OSYd0DKbA4jRBsqcB1VDtlwDUhqx6oInVIKX5VE7lilyBfAe54iANIoi+tvMV8zIOyOMgO2pz41dhBj8ZkAFGGHDdHKkIzwCTi98ZLG2zLMZzZE+3O5Gs+A/yF6DEyTZpst2dqQjPAVystekuLhRSly3JbsdrbdRQstfAksc1XlCauzuLlwun2QMSZRtrjr8oTyuIsZ8LhOkYAh4C3XOA8MSMA7rkFe90Ok6QX7ee2Br8nwqE+glyEp8huwEaj6xEegSooNYaejYfDrECBlRlBe8o03J+YF3+tIiGEIgIt4FjgUK8dcCJ/TyvZ4KWJCsyxFOIjbIcd8+AnlBgk4FSdJvA4BEnCKFHcx+1OFLyoI6+KagQQMAcgwHwNPxkjRJyU+SkRLEknOw2szqAwSsC7OUfJcJNKhP5GhFxhziDjMDJuTMgON+HmpwGVUGQU6IqgngZukzI9J1k+2Q4AUOYtwBzAeQhsHupM2Aw0wBFDfKq9n/pVEBeFeKTvcNjigIYYApMze+unOXFNVlB4p8X6j6jYcmmOj5qhpjprm/5M/UZKH5tmqWZ66ELX+AOQZQbFUXt8bAAAAAElFTkSuQmCC'
+
   return {
     initializeMap: initializeMap,
     register: register
@@ -63,8 +65,6 @@ var jekyllMapbox = (function() {
 
       map.on('load', function() {
 
-        console.log(geoJSON);
-
         map.addSource("features", {
           type: "geojson",
           data: geoJSON,
@@ -74,7 +74,8 @@ var jekyllMapbox = (function() {
         })
 
         // https://docs.mapbox.com/mapbox-gl-js/example/add-image/
-        map.loadImage('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADQAAAA0CAYAAADFeBvrAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAADwAAAA8ABA9l7mgAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAASrSURBVGiB3ZpPaFxVFMZ/Z8bGTFLQEhWhaa0lYGvcSERQZ6YjhS6iuLKxaqXVWtFFQPxTazZWK1QRl0HQ+GclJSlYsVUpVCczL41oA9JqW7FUWxVLbTWgSTCZmeMiU42a+969972p4Le93znn+zj3vXf/PPifQZJOqHmWoKwCbkRZgbAMSNeHK8C3CMeAT5mhKKP8kGT9RAxpgWYq3IPwAHCzQ94ayggpXqeVnfIBv8fVEsuQdtJEG4+g9AFXxNRyGuF5JnhVxpjxTeJtSLNkEQaAa3xzGHCUFJtkmFGf4JRPkObYgjBM8mYAVlKjrFke8wl26pBCihz9wMM+xZyh9BPQK6C2IdaGFIQcbwIbvMT5Y4AyD9masp9yObZx4c0APEiWPluyVYc0TzfKHlt+A6Ao3RLwYRQxUqCuoZUpjgBLPcVUEU7XZV3JXx9ZV3xDhU4ZZSqMFD3lJnkCdzPTKP1AgTTNUqJdSrQzSQblVuAVYNox59Wko998oR3SAgup8j1wiUPhMZQeCTgRkbuDKoPA9Q65x8nQLvuYMBHCO1RlPW5m9jNJPsoMgBQ5ToYcUHTIfylT3B1GiJpyax2KnUBZK2NM2gbIPiZo4k7gpEOdUE1GQ1pgIZCzLqNslYBf7HXNQvZzDuVph5BV2kWLadDcoQqdwALLIt8RsMtB1N8RsBOx3kZcTDPXmgbNhlKscJC0x2V58k/UY/c6BKw0DZkN1Whz0HTUgWvCEWummLWFdcg4T+cp8LM11wTlnAPb4xmqOYh066YJlztwjdrCOnTWOr04PW/xcwhnTENmQ8oxBzm3a5zd72zsbQ4BRm1mQ2UOg/W8XkI+/Aseiiz3oSy2ZJ+hbH4JGQ0JKMIBa1HKds2yyJp/Pmw1bQjPOYQcCPtEhC99lEGHQssRhsK+4v9Kv4ZWptkFXGVdJUJTuKE0u8G8sp0Hq2mhpFmWR+oq0MEUZaDgkP9Xpng3jBC9wcvxBnC/Q1GY3Q+9hjBEmhEpUgHQLhaQ4RaEHmAT0OSYd0DKbA4jRBsqcB1VDtlwDUhqx6oInVIKX5VE7lilyBfAe54iANIoi+tvMV8zIOyOMgO2pz41dhBj8ZkAFGGHDdHKkIzwCTi98ZLG2zLMZzZE+3O5Gs+A/yF6DEyTZpst2dqQjPAVystekuLhRSly3JbsdrbdRQstfAksc1XlCauzuLlwun2QMSZRtrjr8oTyuIsZ8LhOkYAh4C3XOA8MSMA7rkFe90Ok6QX7ee2Br8nwqE+glyEp8huwEaj6xEegSooNYaejYfDrECBlRlBe8o03J+YF3+tIiGEIgIt4FjgUK8dcCJ/TyvZ4KWJCsyxFOIjbIcd8+AnlBgk4FSdJvA4BEnCKFHcx+1OFLyoI6+KagQQMAcgwHwNPxkjRJyU+SkRLEknOw2szqAwSsC7OUfJcJNKhP5GhFxhziDjMDJuTMgON+HmpwGVUGQU6IqgngZukzI9J1k+2Q4AUOYtwBzAeQhsHupM2Aw0wBFDfKq9n/pVEBeFeKTvcNjigIYYApMze+unOXFNVlB4p8X6j6jYcmmOj5qhpjprm/5M/UZKH5tmqWZ66ELX+AOQZQbFUXt8bAAAAAElFTkSuQmCC', function(error, image) {
+        let markerIcon = mapOptions.markerIcon || MarkerIconDefault;
+        map.loadImage(markerIcon, function(error, image) {
           if (error) throw error;
           map.addImage('marker-custom', image);
 

--- a/lib/jekyll-maps/mapbox_api.rb
+++ b/lib/jekyll-maps/mapbox_api.rb
@@ -1,0 +1,84 @@
+module Jekyll
+  module Maps
+    class MapboxApi
+      HEAD_END_TAG = %r!</[\s\t]*head>!
+
+      class << self
+        def prepend_api_code(doc)
+          @config = doc.site.config
+          if doc.output =~ HEAD_END_TAG
+            # Insert API code before header's end if this document has one.
+            doc.output.gsub!(HEAD_END_TAG, %(#{api_code}#{Regexp.last_match}))
+          else
+            doc.output.prepend(api_code)
+          end
+        end
+
+        private
+        def api_code
+          <<HTML
+<script type='text/javascript'>
+  #{js_lib_contents}
+</script>
+#{load_mapbox_api}
+#{load_marker_cluster}
+HTML
+        end
+
+        private
+        def load_mapbox_api
+          access_token = @config.fetch("maps", {})
+            .fetch("mapbox", {})
+            .fetch("access_token", "")
+          <<HTML
+
+<script async defer src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.0/mapbox-gl.js' onload='#{Jekyll::Maps::MapboxTag::JS_LIB_NAME}.initializeMap("#{access_token}")'></script>
+<link async defer href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.0/mapbox-gl.css' rel='stylesheet' />
+<style>
+  .marker {
+    background-image: url('https://docs.mapbox.com/help/demos/custom-markers-gl-js/mapbox-icon.png');
+    background-size: cover;
+    width: 50px;
+    height: 50px;
+    border-radius: 50%;
+    cursor: pointer;
+  }
+</style>
+HTML
+        end
+
+        private
+        def load_marker_cluster
+          settings = @config.fetch("maps", {})
+            .fetch("google", {})
+            .fetch("marker_cluster", {})
+          return unless settings.fetch("enabled", true)
+          <<HTML
+<!-- <script async defer src='https://cdn.rawgit.com/googlemaps/js-marker-clusterer/gh-pages/src/markerclusterer.js'
+        onload='#{Jekyll::Maps::GoogleMapTag::JS_LIB_NAME}.initializeCluster(#{settings.to_json})'></script> //-->
+HTML
+        end
+
+        private
+        def js_lib_contents
+          @js_lib_contents ||= begin
+            File.read(js_lib_path)
+          end
+        end
+
+        private
+        def js_lib_path
+          @js_lib_path ||= begin
+            File.expand_path("./mapbox_api.js", File.dirname(__FILE__))
+          end
+        end
+      end
+    end
+  end
+end
+
+Jekyll::Hooks.register [:pages, :documents], :post_render do |doc|
+  if doc.output =~ %r!#{Jekyll::Maps::MapboxTag::JS_LIB_NAME}!
+    Jekyll::Maps::MapboxApi.prepend_api_code(doc)
+  end
+end

--- a/lib/jekyll-maps/mapbox_api.rb
+++ b/lib/jekyll-maps/mapbox_api.rb
@@ -42,6 +42,13 @@ HTML
     border-radius: 50%;
     cursor: pointer;
   }
+
+  .mapboxgl-popup {
+    max-width: 400px;
+  }
+  .mapboxgl-popup-content {
+    padding: 20px 10px 15px 10px;
+  }
 </style>
 HTML
         end

--- a/lib/jekyll-maps/mapbox_api.rb
+++ b/lib/jekyll-maps/mapbox_api.rb
@@ -34,15 +34,6 @@ HTML
 <script async defer src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.0/mapbox-gl.js' onload='#{Jekyll::Maps::MapboxTag::JS_LIB_NAME}.initializeMap("#{access_token}")'></script>
 <link async defer href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.54.0/mapbox-gl.css' rel='stylesheet' />
 <style>
-  .marker {
-    background-image: url('https://docs.mapbox.com/help/demos/custom-markers-gl-js/mapbox-icon.png');
-    background-size: cover;
-    width: 50px;
-    height: 50px;
-    border-radius: 50%;
-    cursor: pointer;
-  }
-
   .mapboxgl-popup {
     max-width: 400px;
   }

--- a/lib/jekyll-maps/mapbox_api.rb
+++ b/lib/jekyll-maps/mapbox_api.rb
@@ -21,7 +21,6 @@ module Jekyll
   #{js_lib_contents}
 </script>
 #{load_mapbox_api}
-#{load_marker_cluster}
 HTML
         end
 
@@ -44,18 +43,6 @@ HTML
     cursor: pointer;
   }
 </style>
-HTML
-        end
-
-        private
-        def load_marker_cluster
-          settings = @config.fetch("maps", {})
-            .fetch("google", {})
-            .fetch("marker_cluster", {})
-          return unless settings.fetch("enabled", true)
-          <<HTML
-<!-- <script async defer src='https://cdn.rawgit.com/googlemaps/js-marker-clusterer/gh-pages/src/markerclusterer.js'
-        onload='#{Jekyll::Maps::GoogleMapTag::JS_LIB_NAME}.initializeCluster(#{settings.to_json})'></script> //-->
 HTML
         end
 

--- a/lib/jekyll-maps/mapbox_tag.rb
+++ b/lib/jekyll-maps/mapbox_tag.rb
@@ -1,0 +1,73 @@
+module Jekyll
+  module Maps
+    class MapboxTag < Liquid::Tag
+      JS_LIB_NAME        = "jekyllMapbox".freeze
+      DEFAULT_MAP_WIDTH  = 600
+      DEFAULT_MAP_HEIGHT = 400
+
+      def initialize(_, args, _)
+        @args   = OptionsParser.parse(args)
+        @finder = LocationFinder.new(@args)
+        super
+      end
+
+      def render(context)
+        locations = @finder.find(context.registers[:site], context.registers[:page])
+        @args[:attributes][:id] ||= SecureRandom.uuid
+
+        <<HTML
+<div #{render_attributes}></div>
+<script type='text/javascript'>
+  #{JS_LIB_NAME}.register(
+    '#{@args[:attributes][:id]}',
+    #{locations.to_json},
+    #{map_options(context.registers[:site]).to_json}
+  );
+</script>
+HTML
+      end
+
+      private
+      def render_attributes
+        attributes = []
+        attributes << "id='#{@args[:attributes][:id]}'"
+        attributes << render_dimensions
+        attributes << render_class if @args[:attributes][:class]
+        attributes.join(" ")
+      end
+
+      private
+      def render_dimensions
+        width       = @args[:attributes][:width] || DEFAULT_MAP_WIDTH
+        height      = @args[:attributes][:height] || DEFAULT_MAP_HEIGHT
+        width_unit  = width.to_s.include?("%") ? "" : "px"
+        height_unit = height.to_s.include?("%") ? "" : "px"
+        %(style='width:#{width}#{width_unit};height:#{height}#{height_unit};')
+      end
+
+      private
+      def render_class
+        css = @args[:attributes][:class]
+        css = css.join(" ") if css.is_a?(Array)
+        %(class='#{css}')
+      end
+
+      private
+      def map_options(site)
+        opts = {
+          :baseUrl         => site.baseurl || "/",
+          :useCluster      => !@args[:flags][:no_cluster],
+          :showMarker      => @args[:attributes][:show_marker] != "false",
+          :showMarkerPopup => @args[:attributes][:show_popup] != "false",
+          :markerIcon      => @args[:attributes][:marker_icon]
+        }
+        if @args[:attributes][:zoom]
+          opts[:customZoom] = @args[:attributes][:zoom].to_i
+        end
+        opts
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag("mapbox", Jekyll::Maps::MapboxTag)


### PR DESCRIPTION
This PR is linked to issue #27 . The engine Mapbox GL JS to display vector maps allows to use OSM data from various sources (cloud or selfhosted).

The current development effort is to make mapbox working as good as Google. The next step is to make it also compatible/configure with https://openmaptiles.com/ or https://cloud.maptiler.com/

Some design decisions are required:

- Should the switch between Google and Mapbox be a different Jekyll Tag or should it rather be a (global) configuration option?
- How could the code be restructured to achive less duplication? Mapbox examples all use GeoJSON for data. I think it could be interesting to also make the Google Maps part use internally the structure of GeoJSON for lists of markers.