### PR TITLE
Support for Jekyll v4

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,6 @@
+## 2.4.0
+* support jekyll v4
+
 ## 2.3.0 / 2018-03-17
 
 * customize popup link text (#34)

--- a/jekyll-maps.gemspec
+++ b/jekyll-maps.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r!^(test|spec|features)/!) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jekyll", "~> 3.0"
+  spec.add_dependency "jekyll", ">= 3.0", "< 5.0"
 
   spec.add_development_dependency "rake", "~> 11.0"
   spec.add_development_dependency "rspec", "~> 3.5"


### PR DESCRIPTION
This updates the changelog and gemspec to support jekyll versions up to (excluding) 5.

Here is the full migration guide: https://jekyllrb.com/docs/upgrading/3-to-4/#for-plugin-authors. After a superficial check it seems there should be no issue with using jekyll v4 (you already use `Liquid::Template.parse()` instead of `site.liquid_renderer.file(path).parse(content)`.